### PR TITLE
Use HTSlib API to set the CRAM reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # use g++ compiler
 CXX=g++
-CXXFLAGS?=-std=c++11 -fpermissive
+CXXFLAGS?=-Wall -pedantic -std=c++11
 
 # flag specifications for release and debug
 RELEASEFLAGS?=$(CXXFLAGS) -O3

--- a/count.cpp
+++ b/count.cpp
@@ -67,17 +67,17 @@ counts_t compute_counts(const char* const in_reads_fn, std::string const & ref, 
         std::cerr << "Not a CRAM/BAM/SAM file: " << in_reads_fn << std::endl; exit(1);
     }
 
+    // if CRAM file, load reference in htslib
+    if(reads->format.format == cram) {
+        hts_set_opt(reads, CRAM_OPT_REFERENCE, user_args.in_ref_fn);
+    }
+
     // set up htsFile for parsing
     bam_hdr_t* header = sam_hdr_read(reads);
     if(!header) {
         std::cerr << "Unable to open CRAM/BAM/SAM header: " << in_reads_fn << std::endl; exit(1);
     } else if(header->n_targets != 1) {
         std::cerr << "CRAM/BAM/SAM has " << header->n_targets << " references, but it should have exactly 1: " << in_reads_fn << std::endl; exit(1);
-    }
-
-    // if CRAM file, load reference in htslib
-    if(reads->format.format == cram) {
-        cram_load_reference((reads->fp).cram, user_args.in_ref_fn);
     }
 
     // prepare helper variables for computing counts

--- a/count.h
+++ b/count.h
@@ -1,6 +1,5 @@
 #ifndef COUNT_H
 #define COUNT_H
-#include "htslib/cram/cram.h"
 #include "common.h"
 #include "argparse.h"
 


### PR DESCRIPTION
cram_load_reference() is an internal HTSlib function, and shouldn't be called directly.  Instead use hts_set_opt() to tell the CRAM reader which reference it should use.

As the (HTSlib-internal) cram/cram.h file no longer needs to be included in ViralConsensus code, the change to CXXFLAGS in commit 0b99fca can also be reverted.